### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostSmartPtrConfig.cmake
+++ b/BoostSmartPtrConfig.cmake
@@ -1,0 +1,14 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostAssert 1.66)
+find_dependency(BoostConfig 1.66)
+find_dependency(BoostCore 1.66)
+find_dependency(BoostMove 1.66)
+find_dependency(BoostPredef 1.66)
+find_dependency(BoostStaticAssert 1.66)
+find_dependency(BoostThrowException 1.66)
+find_dependency(BoostTypeTraits 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostSmartPtrTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostSmartPtr VERSION 1.66 LANGUAGES CXX)
+
+add_library(smart_ptr INTERFACE)
+
+target_include_directories(smart_ptr INTERFACE 
+    $<BUILD_INTERFACE:${BoostSmartPtr_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostSmartPtr_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostAssert 1.66 REQUIRED)
+find_package(BoostConfig 1.66 REQUIRED)
+find_package(BoostCore 1.66 REQUIRED)
+find_package(BoostMove 1.66 REQUIRED)
+find_package(BoostPredef 1.66 REQUIRED)
+find_package(BoostStaticAssert 1.66 REQUIRED)
+find_package(BoostThrowException 1.66 REQUIRED)
+find_package(BoostTypeTraits 1.66 REQUIRED)
+
+target_link_libraries(smart_ptr
+    INTERFACE
+        Boost::assert
+        Boost::config
+        Boost::core
+        Boost::move
+        Boost::predef
+        Boost::static_assert
+        Boost::throw_exception
+        Boost::type_traits
+    )
+
+install(EXPORT smart_ptr-targets
+    FILE BoostSmartPtrTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS smart_ptr EXPORT smart_ptr-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostSmartPtrConfigVersion.cmake"
+    VERSION ${BoostSmartPtr_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostSmartPtrConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostSmartPtrConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::smart_ptr ALIAS smart_ptr)


### PR DESCRIPTION
Expresses Boost::smart_ptr as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostSmartPtr 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── detail
│       │   ├── atomic_count.hpp
│       │   ├── lightweight_mutex.hpp
│       │   ├── lightweight_thread.hpp
│       │   └── quick_allocator.hpp
│       ├── enable_shared_from_this.hpp
│       ├── intrusive_ptr.hpp
│       ├── make_shared.hpp
│       ├── make_unique.hpp
│       ├── pointer_cast.hpp
│       ├── pointer_to_other.hpp
│       ├── scoped_array.hpp
│       ├── scoped_ptr.hpp
│       ├── shared_array.hpp
│       ├── shared_ptr.hpp
│       ├── smart_ptr
│       │   ├── allocate_local_shared_array.hpp
│       │   ├── allocate_shared_array.hpp
│       │   ├── atomic_shared_ptr.hpp
│       │   ├── bad_weak_ptr.hpp
│       │   ├── detail
│       │   │   ├── atomic_count_gcc.hpp
│       │   │   ├── atomic_count_gcc_x86.hpp
│       │   │   ├── atomic_count.hpp
│       │   │   ├── atomic_count_nt.hpp
│       │   │   ├── atomic_count_pt.hpp
│       │   │   ├── atomic_count_solaris.hpp
│       │   │   ├── atomic_count_spin.hpp
│       │   │   ├── atomic_count_std_atomic.hpp
│       │   │   ├── atomic_count_sync.hpp
│       │   │   ├── atomic_count_win32.hpp
│       │   │   ├── lightweight_mutex.hpp
│       │   │   ├── local_counted_base.hpp
│       │   │   ├── local_sp_deleter.hpp
│       │   │   ├── lwm_nop.hpp
│       │   │   ├── lwm_pthreads.hpp
│       │   │   ├── lwm_win32_cs.hpp
│       │   │   ├── operator_bool.hpp
│       │   │   ├── quick_allocator.hpp
│       │   │   ├── shared_count.hpp
│       │   │   ├── sp_convertible.hpp
│       │   │   ├── sp_counted_base_acc_ia64.hpp
│       │   │   ├── sp_counted_base_aix.hpp
│       │   │   ├── sp_counted_base_clang.hpp
│       │   │   ├── sp_counted_base_cw_ppc.hpp
│       │   │   ├── sp_counted_base_cw_x86.hpp
│       │   │   ├── sp_counted_base_gcc_ia64.hpp
│       │   │   ├── sp_counted_base_gcc_mips.hpp
│       │   │   ├── sp_counted_base_gcc_ppc.hpp
│       │   │   ├── sp_counted_base_gcc_sparc.hpp
│       │   │   ├── sp_counted_base_gcc_x86.hpp
│       │   │   ├── sp_counted_base.hpp
│       │   │   ├── sp_counted_base_nt.hpp
│       │   │   ├── sp_counted_base_pt.hpp
│       │   │   ├── sp_counted_base_snc_ps3.hpp
│       │   │   ├── sp_counted_base_solaris.hpp
│       │   │   ├── sp_counted_base_spin.hpp
│       │   │   ├── sp_counted_base_std_atomic.hpp
│       │   │   ├── sp_counted_base_sync.hpp
│       │   │   ├── sp_counted_base_vacpp_ppc.hpp
│       │   │   ├── sp_counted_base_w32.hpp
│       │   │   ├── sp_counted_impl.hpp
│       │   │   ├── sp_disable_deprecated.hpp
│       │   │   ├── sp_forward.hpp
│       │   │   ├── sp_has_sync.hpp
│       │   │   ├── spinlock_gcc_arm.hpp
│       │   │   ├── spinlock.hpp
│       │   │   ├── spinlock_nt.hpp
│       │   │   ├── spinlock_pool.hpp
│       │   │   ├── spinlock_pt.hpp
│       │   │   ├── spinlock_std_atomic.hpp
│       │   │   ├── spinlock_sync.hpp
│       │   │   ├── spinlock_w32.hpp
│       │   │   ├── sp_interlocked.hpp
│       │   │   ├── sp_noexcept.hpp
│       │   │   ├── sp_nullptr_t.hpp
│       │   │   └── yield_k.hpp
│       │   ├── enable_shared_from_raw.hpp
│       │   ├── enable_shared_from_this.hpp
│       │   ├── intrusive_ptr.hpp
│       │   ├── intrusive_ref_counter.hpp
│       │   ├── local_shared_ptr.hpp
│       │   ├── make_local_shared_array.hpp
│       │   ├── make_local_shared.hpp
│       │   ├── make_local_shared_object.hpp
│       │   ├── make_shared_array.hpp
│       │   ├── make_shared.hpp
│       │   ├── make_shared_object.hpp
│       │   ├── make_unique.hpp
│       │   ├── owner_less.hpp
│       │   ├── scoped_array.hpp
│       │   ├── scoped_ptr.hpp
│       │   ├── shared_array.hpp
│       │   ├── shared_ptr.hpp
│       │   └── weak_ptr.hpp
│       ├── smart_ptr.hpp
│       └── weak_ptr.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostSmartPtrConfig.cmake
            ├── BoostSmartPtrConfigVersion.cmake
            └── BoostSmartPtrTargets.cmake

8 directories, 97 files
```
- tests are __not__ included in the build